### PR TITLE
Read order from provider instead of fetchOrder

### DIFF
--- a/packages/my-account/src/pages/OrderPage/index.tsx
+++ b/packages/my-account/src/pages/OrderPage/index.tsx
@@ -1,7 +1,6 @@
 import { OrderContainer } from "@commercelayer/react-components/orders/OrderContainer"
 import { OrderNumber } from "@commercelayer/react-components/orders/OrderNumber"
-import type { Order } from "@commercelayer/sdk"
-import { useState, useContext } from "react"
+import { useContext } from "react"
 import { Trans } from "react-i18next"
 import { Redirect } from "wouter"
 
@@ -30,23 +29,22 @@ function OrderPage({ orderId }: OrderPageProps): JSX.Element {
   const ctx = useContext(AppContext)
   const accessToken = ctx?.accessToken
 
-  const [order, setOrder] = useState<Order>()
-  const orderPlacedAt =
-    (order?.placed_at && formatDate(order.placed_at, shortDate)) || ""
-  const orderStatus = order ? (order.status as OrderStatus) : "placed"
-
   return (
     <OrderProvider
       orderId={orderId}
       accessToken={accessToken as string}
       domain={ctx?.domain as string}
     >
-      {({ invalidOrder }) => {
+      {({ order, invalidOrder }) => {
+        const orderPlacedAt =
+          (order?.placed_at && formatDate(order.placed_at, shortDate)) || ""
+        const orderStatus = order ? (order.status as OrderStatus) : "placed"
+
         if (invalidOrder) {
           return <Redirect to={`/orders?accessToken=${accessToken}`} />
         } else {
           return (
-            <OrderContainer orderId={orderId} fetchOrder={setOrder}>
+            <OrderContainer orderId={orderId}>
               <SkeletonMainOrder visible={order === undefined} />
               <OrderWrapper hidden={order === undefined}>
                 <OrderHeader>

--- a/packages/my-account/src/utils/getOrder.ts
+++ b/packages/my-account/src/utils/getOrder.ts
@@ -31,6 +31,7 @@ const getAsyncOrder = async (client: CommerceLayerClient, orderId: string) => {
       orders: [
         "id",
         "status",
+        "placed_at",
         "number",
         "guest",
         "shipping_address",


### PR DESCRIPTION
### What does this PR do?
Remove usage of `OrderContainer` `fetchOrder` prop that was set to update `order` state with update order data from OrderProvider. Now `order` data is read directly from `OrderProvider` data.