### PR TITLE
Set orders table date to `placed_at` date

### DIFF
--- a/packages/my-account/src/pages/OrdersPage/index.tsx
+++ b/packages/my-account/src/pages/OrdersPage/index.tsx
@@ -12,7 +12,7 @@ import {
   OrderData,
   OrderNumber,
   OrderItemsCount,
-  OrderUpdatedDate,
+  OrderDate,
 } from "./styled"
 
 import Empty from "#components/composite/Empty"
@@ -39,7 +39,7 @@ function OrdersPage(): JSX.Element {
     },
     {
       Header: "Date",
-      accessor: "updated_at",
+      accessor: "placed_at",
       className: colClassName,
       titleClassName,
     },
@@ -112,7 +112,7 @@ function OrdersPage(): JSX.Element {
             }}
           </OrderListRow>
           <OrderListRow
-            field="updated_at"
+            field="placed_at"
             className="absolute order-2 text-right bottom-4 right-5 md:bottom-auto md:relative md:right-auto md:text-left"
           >
             {({ cell, row, ...p }) => {
@@ -121,9 +121,9 @@ function OrdersPage(): JSX.Element {
               const cols = cell?.map((cell) => {
                 return (
                   <OrderData key={order.number} {...p} {...cell.getCellProps()}>
-                    <OrderUpdatedDate>
+                    <OrderDate>
                       {cell.value && formatDate(cell.value, shortDate)}
-                    </OrderUpdatedDate>
+                    </OrderDate>
                   </OrderData>
                 )
               })

--- a/packages/my-account/src/pages/OrdersPage/styled.tsx
+++ b/packages/my-account/src/pages/OrdersPage/styled.tsx
@@ -21,6 +21,6 @@ export const OrderItemsCount = styled.p`
   ${tw`text-sm font-light text-gray-400`}
 `
 
-export const OrderUpdatedDate = styled.p`
+export const OrderDate = styled.p`
   ${tw`inline-block text-sm font-extralight text-gray-400 bg-gray-200 px-3 rounded-full h-5 md:(bg-contrast px-0 w-min)`}
 `


### PR DESCRIPTION
### What does this PR do?
Set orders table date to `placed_at` date in order to have the same date information between orders list and order detail page.

Closes #113 