### PR TITLE
Add readonly Wallet page

### DIFF
--- a/packages/my-account/index.html
+++ b/packages/my-account/index.html
@@ -11,11 +11,11 @@
     />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
   </head>
-  <body className="bg-gray-50">
+  <body class="bg-gray-50">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/my-account/index.html
+++ b/packages/my-account/index.html
@@ -11,7 +11,7 @@
     />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/packages/my-account/package.json
+++ b/packages/my-account/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@commercelayer/react-components": "4.2.3-beta.0",
     "@commercelayer/react-utils": "1.0.0-beta.3",
-    "@commercelayer/sdk": "^4.20.0",
+    "@commercelayer/sdk": "^4.24.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@headlessui/react": "^1.6.4",
     "@tailwindcss/forms": "^0.5.2",

--- a/packages/my-account/package.json
+++ b/packages/my-account/package.json
@@ -40,7 +40,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@commercelayer/react-components": "4.1.0",
+    "@commercelayer/react-components": "4.2.3-beta.0",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "^4.20.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",

--- a/packages/my-account/package.json
+++ b/packages/my-account/package.json
@@ -40,7 +40,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@commercelayer/react-components": "4.2.3-beta.0",
+    "@commercelayer/react-components": "4.2.3-beta.1",
     "@commercelayer/react-utils": "1.0.0-beta.3",
     "@commercelayer/sdk": "^4.24.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",

--- a/packages/my-account/src/App.tsx
+++ b/packages/my-account/src/App.tsx
@@ -13,6 +13,7 @@ const LazyOrdersPage = lazy(() => import("#pages/OrdersPage"))
 const LazyParcelPage = lazy(() => import("#pages/ParcelPage"))
 const LazyAddressFormPage = lazy(() => import("#pages/AdddressFormPage"))
 const LazyAddressesPage = lazy(() => import("#pages/AddressesPage"))
+const LazyWalletPage = lazy(() => import("#pages/WalletPage"))
 
 const basePath =
   import.meta.env.PUBLIC_PROJECT_PATH != null
@@ -84,6 +85,11 @@ function App(): JSX.Element {
                       <Route path={appRoutes.addresses.path}>
                         <Suspense fallback={<></>}>
                           <LazyAddressesPage />
+                        </Suspense>
+                      </Route>
+                      <Route path={appRoutes.wallet.path}>
+                        <Suspense fallback={<></>}>
+                          <LazyWalletPage />
                         </Suspense>
                       </Route>
                       <Route>

--- a/packages/my-account/src/assets/locales/en/common.json
+++ b/packages/my-account/src/assets/locales/en/common.json
@@ -123,7 +123,6 @@
     "creditCard": "Credit card",
     "number": "**** **** **** ",
     "endingIn": "ending in <0/>",
-    "validUntil": "valid until <0/>/<1/>",
     "expires": "expires <0/>/<1/>",
     "wireTransfer": "Wire transfer",
     "wireTransferDescription": "Upon order confirmation, you'll receive wiring instructions to complete payment",

--- a/packages/my-account/src/assets/locales/en/common.json
+++ b/packages/my-account/src/assets/locales/en/common.json
@@ -121,9 +121,8 @@
   },
   "paymentSource": {
     "creditCard": "Credit card",
-    "number": "**** **** **** ",
     "endingIn": "ending in <0/>",
-    "expires": "expires <0/>/<1/>",
+    "expires": "expires ",
     "wireTransfer": "Wire transfer",
     "wireTransferDescription": "Upon order confirmation, you'll receive wiring instructions to complete payment",
     "paypalDescription": "After placing the order, you will be redirected to the PayPal website to sign in and authorize the payment"

--- a/packages/my-account/src/assets/locales/en/common.json
+++ b/packages/my-account/src/assets/locales/en/common.json
@@ -73,15 +73,7 @@
       }
     },
     "payments": {
-      "title": "Payments",
-      "paymentMethod": {
-        "creditCard": "Credit card",
-        "EndingIn": "ending in <0/>",
-        "ValidUntil": "valid until <0/>/<1/>",
-        "wireTransfer": "Wire transfer",
-        "wireTransferDescription": "Upon order confirmation, you'll receive wiring instructions to complete payment",
-        "paypalDescription": "After placing the order, you will be redirected to the PayPal website to sign in and authorize the payment"
-      }
+      "title": "Payments"
     }
   },
   "addresses": {
@@ -119,10 +111,23 @@
     "description": "Looks like you haven't saved any address yet",
     "buttonLabel": "Add an address"
   },
+  "wallet": {
+    "title": "My Wallet"
+  },
   "noPaymentMethods": {
     "title": "No payment method yet",
     "description": "Looks like you haven’t saved any payment method yet",
     "buttonLabel": "Add a payment method"
+  },
+  "paymentSource": {
+    "creditCard": "Credit card",
+    "number": "**** **** **** ",
+    "endingIn": "ending in <0/>",
+    "validUntil": "valid until <0/>/<1/>",
+    "expires": "expires <0/>/<1/>",
+    "wireTransfer": "Wire transfer",
+    "wireTransferDescription": "Upon order confirmation, you'll receive wiring instructions to complete payment",
+    "paypalDescription": "After placing the order, you will be redirected to the PayPal website to sign in and authorize the payment"
   },
   "returns": {
     "title": "My returns"

--- a/packages/my-account/src/assets/locales/it/common.json
+++ b/packages/my-account/src/assets/locales/it/common.json
@@ -73,15 +73,7 @@
       }
     },
     "payments": {
-      "title": "Pagamenti",
-      "paymentMethod": {
-        "creditCard": "Carta di credito",
-        "EndingIn": "finisce con <0/>",
-        "ValidUntil": "valida fino al <0/>/<1/>",
-        "wireTransfer": "Bonifico bancario",
-        "wireTransferDescription": "Dopo la conferma dell'ordine riceverai le istruzioni per completare il pagamento",
-        "paypalDescription": "Dopo aver effettuato l'ordine, sarai reindirizzato verso il sito PayPal per accedere e autorizzare il pagamento"
-      }
+      "title": "Pagamenti"
     }
   },
   "addresses": {
@@ -119,10 +111,23 @@
     "description": "Sembra che tu non abbaia ancora nessun indirizzo salvato",
     "buttonLabel": "Aggiungi un indirizzo"
   },
+  "wallet": {
+    "title": "Il mio Wallet"
+  },
   "noPaymentMethods": {
     "title": "Nessun metodo di pagamento",
     "description": "Sembra che tu non ancora nessun metodo di pagamento salvato",
     "buttonLabel": "Aggiungi un metodo di pagamento"
+  },
+  "paymentSource": {
+    "creditCard": "Carta di credito",
+    "number": "**** **** **** ",
+    "endingIn": "finisce con <0/>",
+    "validUntil": "valida fino al <0/>/<1/>",
+    "expires": "scade <0/>/<1/>",
+    "wireTransfer": "Bonifico bancario",
+    "wireTransferDescription": "Dopo la conferma dell'ordine riceverai le istruzioni per completare il pagamento",
+    "paypalDescription": "Dopo aver effettuato l'ordine, sarai reindirizzato verso il sito PayPal per accedere e autorizzare il pagamento"
   },
   "returns": {
     "title": "I miei resi"

--- a/packages/my-account/src/assets/locales/it/common.json
+++ b/packages/my-account/src/assets/locales/it/common.json
@@ -123,7 +123,6 @@
     "creditCard": "Carta di credito",
     "number": "**** **** **** ",
     "endingIn": "finisce con <0/>",
-    "validUntil": "valida fino al <0/>/<1/>",
     "expires": "scade <0/>/<1/>",
     "wireTransfer": "Bonifico bancario",
     "wireTransferDescription": "Dopo la conferma dell'ordine riceverai le istruzioni per completare il pagamento",

--- a/packages/my-account/src/assets/locales/it/common.json
+++ b/packages/my-account/src/assets/locales/it/common.json
@@ -121,9 +121,8 @@
   },
   "paymentSource": {
     "creditCard": "Carta di credito",
-    "number": "**** **** **** ",
     "endingIn": "finisce con <0/>",
-    "expires": "scade <0/>/<1/>",
+    "expires": "scade ",
     "wireTransfer": "Bonifico bancario",
     "wireTransferDescription": "Dopo la conferma dell'ordine riceverai le istruzioni per completare il pagamento",
     "paypalDescription": "Dopo aver effettuato l'ordine, sarai reindirizzato verso il sito PayPal per accedere e autorizzare il pagamento"

--- a/packages/my-account/src/components/composite/Address/AddressInputGroup/index.tsx
+++ b/packages/my-account/src/components/composite/Address/AddressInputGroup/index.tsx
@@ -1,7 +1,6 @@
 import type {
-  BaseInputType,
-  ResourceErrorType,
-  ErrorComponentProps,
+  TResourceError,
+  TErrorComponent,
 } from "@commercelayer/react-components"
 import type { Address } from "@commercelayer/sdk"
 import { useEffect, useState } from "react"
@@ -19,9 +18,9 @@ import { Label } from "#components/ui/form/Label"
 import type { AddressFormFields } from "#types/addresses"
 
 interface Props {
-  type: BaseInputType
+  type: string
   fieldName: `billing_address_${Extract<keyof Address, AddressFormFields>}`
-  resource: ResourceErrorType
+  resource: TResourceError
   value?: string
   required?: boolean
 }
@@ -35,7 +34,7 @@ export function AddressInputGroup({
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
-  const messages: ErrorComponentProps["messages"] = [
+  const messages: TErrorComponent["messages"] = [
     {
       code: "VALIDATION_ERROR",
       resource: "billing_address",

--- a/packages/my-account/src/components/composite/Navbar/index.tsx
+++ b/packages/my-account/src/components/composite/Navbar/index.tsx
@@ -56,7 +56,7 @@ function Navbar({ settings, onClick }: Props): JSX.Element {
       title: t("menu.wallet"),
       href: "/wallet",
       icon: <CreditCard className="w-4" />,
-      comingSoon: true,
+      comingSoon: false,
       accessToken,
       onClick,
     },

--- a/packages/my-account/src/components/composite/Order/LineItemTypes/index.tsx
+++ b/packages/my-account/src/components/composite/Order/LineItemTypes/index.tsx
@@ -1,4 +1,4 @@
-import type { LineItemType } from "@commercelayer/react-components"
+import type { TLineItem } from "@commercelayer/react-components"
 import { LineItem } from "@commercelayer/react-components/line_items/LineItem"
 import { LineItemAmount } from "@commercelayer/react-components/line_items/LineItemAmount"
 import { LineItemCode } from "@commercelayer/react-components/line_items/LineItemCode"
@@ -16,7 +16,7 @@ import {
 } from "./styled"
 
 interface Props {
-  type: LineItemType
+  type: TLineItem
 }
 
 export function LineItemTypes({ type }: Props): JSX.Element {

--- a/packages/my-account/src/components/composite/Order/OrderPayments/index.tsx
+++ b/packages/my-account/src/components/composite/Order/OrderPayments/index.tsx
@@ -47,12 +47,12 @@ function OrderPayments(): JSX.Element {
                   <>
                     <PaymentSourceBrandNamePrimary>
                       <OrderPaymentSourceBrandName />
-                      <Trans i18nKey="order.payments.paymentMethod.EndingIn">
+                      <Trans i18nKey="paymentSource.endingIn">
                         <PaymentSourceDetail type="last4" />
                       </Trans>
                     </PaymentSourceBrandNamePrimary>
                     <PaymentSourceBrandNameSecondary>
-                      <Trans i18nKey="order.payments.paymentMethod.ValidUntil">
+                      <Trans i18nKey="paymentSource.validUntil">
                         <PaymentSourceDetail type="exp_month" />
                         <PaymentSourceDetail type="exp_year" />
                       </Trans>

--- a/packages/my-account/src/components/composite/Order/OrderPayments/index.tsx
+++ b/packages/my-account/src/components/composite/Order/OrderPayments/index.tsx
@@ -52,7 +52,7 @@ function OrderPayments(): JSX.Element {
                       </Trans>
                     </PaymentSourceBrandNamePrimary>
                     <PaymentSourceBrandNameSecondary>
-                      <Trans i18nKey="paymentSource.validUntil">
+                      <Trans i18nKey="paymentSource.expires">
                         <PaymentSourceDetail type="exp_month" />
                         <PaymentSourceDetail type="exp_year" />
                       </Trans>

--- a/packages/my-account/src/components/composite/Skeleton/Main/Common/index.tsx
+++ b/packages/my-account/src/components/composite/Skeleton/Main/Common/index.tsx
@@ -6,6 +6,7 @@ import {
   SkeletonTitle,
   SkeletonSpan,
   SkeletonCircle,
+  SkeletonPaymentSourceBrandImage,
 } from "#components/composite/Skeleton/styled"
 import { DesktopOnly, MobileOnly } from "#components/ui/Common/styled"
 
@@ -84,6 +85,24 @@ export function SkeletonMainAddressCard({
           <SkeletonSpan size={"small"} className="ml-36" />
         </SkeletonRow>
       )}
+    </SkeletonCol>
+  )
+}
+
+interface SkeletonMainWalletCardProps {
+  noGap?: boolean
+}
+
+export function SkeletonMainWalletCard({
+  noGap = false,
+}: SkeletonMainWalletCardProps): JSX.Element {
+  const className = `p-4 ${!noGap && "mt-4"}`
+
+  return (
+    <SkeletonCol className={className}>
+      <SkeletonPaymentSourceBrandImage />
+      <SkeletonSpan size="medium" />
+      <SkeletonSpan size="small" />
     </SkeletonCol>
   )
 }

--- a/packages/my-account/src/components/composite/Skeleton/Main/Loader/index.tsx
+++ b/packages/my-account/src/components/composite/Skeleton/Main/Loader/index.tsx
@@ -2,6 +2,7 @@ import { useLocation } from "wouter"
 
 import {
   SkeletonMainAddresses,
+  SkeletonMainWallet,
   SkeletonMainOrders,
   SkeletonMainOrder,
   SkeletonMainParcel,
@@ -12,6 +13,8 @@ export function SkeletonMainLoader(): JSX.Element {
   switch (true) {
     case /\/addresses/.test(location):
       return <SkeletonMainAddresses />
+    case /\/wallet/.test(location):
+      return <SkeletonMainWallet />
     case /\/parcels/.test(location):
       return <SkeletonMainParcel />
     case /\/orders/.test(location):

--- a/packages/my-account/src/components/composite/Skeleton/Main/Wallet/index.tsx
+++ b/packages/my-account/src/components/composite/Skeleton/Main/Wallet/index.tsx
@@ -1,0 +1,18 @@
+import {
+  SkeletonMainPageTitle,
+  SkeletonMainWalletCard,
+} from "#components/composite/Skeleton/Main/Common"
+import { SkeletonWrapper } from "#components/composite/Skeleton/styled"
+
+interface Props {
+  visible?: boolean
+}
+
+export function SkeletonMainWallet({ visible = true }: Props): JSX.Element {
+  return (
+    <SkeletonWrapper visible={visible}>
+      <SkeletonMainPageTitle />
+      <SkeletonMainWalletCard />
+    </SkeletonWrapper>
+  )
+}

--- a/packages/my-account/src/components/composite/Skeleton/Main/index.ts
+++ b/packages/my-account/src/components/composite/Skeleton/Main/index.ts
@@ -1,6 +1,7 @@
 export * from "./Common"
 export * from "./Loader"
 export * from "./Addresses"
+export * from "./Wallet"
 export * from "./Orders"
 export * from "./OrdersTable"
 export * from "./Order"

--- a/packages/my-account/src/components/composite/Skeleton/styled.tsx
+++ b/packages/my-account/src/components/composite/Skeleton/styled.tsx
@@ -136,3 +136,7 @@ export const SkeletonTableTHead = styled(SkeletonTableRow)`
 export const SkeletonTableImg = styled(SkeletonBox)`
   ${tw`flex-shrink-0 w-[75px] h-[75px] md:(w-[85px] h-[85px]) `}
 `
+
+export const SkeletonPaymentSourceBrandImage = styled(SkeletonBox)`
+  ${tw`w-[50px] h-[34px] mb-4`}
+`

--- a/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
+++ b/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
@@ -1,11 +1,12 @@
 import { CustomerPaymentSource } from "@commercelayer/react-components/customers/CustomerPaymentSource"
 
+import { SkeletonMainWalletCard } from "#components/composite/Skeleton/Main/Common"
 import { GridCard } from "#components/ui/GridCard"
 import { PaymentSourceCard } from "#components/ui/PaymentSource/Card"
 
 function CustomerPaymentCard(): JSX.Element {
   return (
-    <CustomerPaymentSource>
+    <CustomerPaymentSource loader={<SkeletonMainWalletCard noGap />}>
       <GridCard>
         <PaymentSourceCard />
       </GridCard>

--- a/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
+++ b/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
@@ -7,7 +7,7 @@ import { PaymentSourceCard } from "#components/ui/PaymentSource/Card"
 function CustomerPaymentCard(): JSX.Element {
   return (
     <CustomerPaymentSource loader={<SkeletonMainWalletCard noGap />}>
-      <GridCard>
+      <GridCard hover="none">
         <PaymentSourceCard />
       </GridCard>
     </CustomerPaymentSource>

--- a/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
+++ b/packages/my-account/src/components/ui/CustomerPaymentCard/index.tsx
@@ -1,0 +1,16 @@
+import { CustomerPaymentSource } from "@commercelayer/react-components/customers/CustomerPaymentSource"
+
+import { GridCard } from "#components/ui/GridCard"
+import { PaymentSourceCard } from "#components/ui/PaymentSource/Card"
+
+function CustomerPaymentCard(): JSX.Element {
+  return (
+    <CustomerPaymentSource>
+      <GridCard>
+        <PaymentSourceCard />
+      </GridCard>
+    </CustomerPaymentSource>
+  )
+}
+
+export default CustomerPaymentCard

--- a/packages/my-account/src/components/ui/GridCard/index.tsx
+++ b/packages/my-account/src/components/ui/GridCard/index.tsx
@@ -1,0 +1,15 @@
+import { Wrapper, Content } from "./styled"
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function GridCard(props: Props): JSX.Element {
+  const { children } = props
+
+  return (
+    <Wrapper>
+      <Content>{children}</Content>
+    </Wrapper>
+  )
+}

--- a/packages/my-account/src/components/ui/GridCard/index.tsx
+++ b/packages/my-account/src/components/ui/GridCard/index.tsx
@@ -1,14 +1,17 @@
 import { Wrapper, Content } from "./styled"
 
+export type GridCardHover = "none"
+
 interface Props {
   children: React.ReactNode
+  hover?: GridCardHover
 }
 
 export function GridCard(props: Props): JSX.Element {
-  const { children } = props
+  const { children, hover } = props
 
   return (
-    <Wrapper>
+    <Wrapper hover={hover}>
       <Content>{children}</Content>
     </Wrapper>
   )

--- a/packages/my-account/src/components/ui/GridCard/styled.tsx
+++ b/packages/my-account/src/components/ui/GridCard/styled.tsx
@@ -8,7 +8,7 @@ interface WrapperProps {
 }
 
 export const Wrapper = styled.div<WrapperProps>`
-  ${tw`rounded-[5px] border border-gray-200 p-[1px]`}
+  ${tw`rounded-[5px] border border-gray-200 p-[1px] bg-white`}
   ${({ hover }) =>
     hover === undefined &&
     tw`hover:(border-primary border-2 shadow-sm-primary p-0)`}

--- a/packages/my-account/src/components/ui/GridCard/styled.tsx
+++ b/packages/my-account/src/components/ui/GridCard/styled.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components"
+import tw from "twin.macro"
+
+export const Wrapper = styled.div`
+  ${tw`rounded border border-gray-200 p-[1px] hover:(border-primary border-2 shadow-sm-primary p-0)`}
+`
+export const Content = styled.div`
+  ${tw`p-4`}
+`

--- a/packages/my-account/src/components/ui/GridCard/styled.tsx
+++ b/packages/my-account/src/components/ui/GridCard/styled.tsx
@@ -1,8 +1,17 @@
 import styled from "styled-components"
 import tw from "twin.macro"
 
-export const Wrapper = styled.div`
-  ${tw`rounded border border-gray-200 p-[1px] hover:(border-primary border-2 shadow-sm-primary p-0)`}
+import type { GridCardHover } from "./index"
+
+interface WrapperProps {
+  hover?: GridCardHover
+}
+
+export const Wrapper = styled.div<WrapperProps>`
+  ${tw`rounded-[5px] border border-gray-200 p-[1px]`}
+  ${({ hover }) =>
+    hover === undefined &&
+    tw`hover:(border-primary border-2 shadow-sm-primary p-0)`}
 `
 export const Content = styled.div`
   ${tw`p-4`}

--- a/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
@@ -18,7 +18,7 @@ export function PaymentSourceCard(): JSX.Element {
   return (
     <PaymentSourceWrapper>
       <PaymentSourceBrandIconWrapper>
-        <PaymentSourceBrandIcon />
+        <PaymentSourceBrandIcon width={50} />
       </PaymentSourceBrandIconWrapper>
       <PaymentSourceBrandNameWrapper>
         <PaymentSourceDetail type="last4">

--- a/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
@@ -34,7 +34,7 @@ export function PaymentSourceCard(): JSX.Element {
                 <PaymentSourceTextWrapper>
                   <PaymentSourceCreditCardNumber />
                 </PaymentSourceTextWrapper>
-                <PaymentSourceCreditCardExpires />
+                <PaymentSourceCreditCardExpires variant="card" />
               </>
             )
           }}

--- a/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Card/index.tsx
@@ -1,0 +1,45 @@
+import { PaymentSourceBrandIcon } from "@commercelayer/react-components/payment_source/PaymentSourceBrandIcon"
+import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
+
+import { PaymentSourceWrapper } from "./styled"
+
+import {
+  PaymentSourceName,
+  PaymentSourceCreditCardNumber,
+  PaymentSourceCreditCardExpires,
+} from "#components/ui/PaymentSource"
+import {
+  PaymentSourceBrandIconWrapper,
+  PaymentSourceBrandNameWrapper,
+  PaymentSourceTextWrapper,
+} from "#components/ui/PaymentSource/styled"
+
+export function PaymentSourceCard(): JSX.Element {
+  return (
+    <PaymentSourceWrapper>
+      <PaymentSourceBrandIconWrapper>
+        <PaymentSourceBrandIcon />
+      </PaymentSourceBrandIconWrapper>
+      <PaymentSourceBrandNameWrapper>
+        <PaymentSourceDetail type="last4">
+          {(props) => {
+            if (props.text === null || props.text.length === 0)
+              return (
+                <PaymentSourceTextWrapper>
+                  <PaymentSourceName />
+                </PaymentSourceTextWrapper>
+              )
+            return (
+              <>
+                <PaymentSourceTextWrapper>
+                  <PaymentSourceCreditCardNumber />
+                </PaymentSourceTextWrapper>
+                <PaymentSourceCreditCardExpires />
+              </>
+            )
+          }}
+        </PaymentSourceDetail>
+      </PaymentSourceBrandNameWrapper>
+    </PaymentSourceWrapper>
+  )
+}

--- a/packages/my-account/src/components/ui/PaymentSource/Card/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Card/styled.tsx
@@ -1,0 +1,6 @@
+import styled from "styled-components"
+import tw from "twin.macro"
+
+export const PaymentSourceWrapper = styled.div`
+  ${tw`rounded flex flex-col gap-6`}
+`

--- a/packages/my-account/src/components/ui/PaymentSource/Row/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Row/index.tsx
@@ -6,7 +6,7 @@ import { PaymentSourceWrapper, PaymentSourceBrandNameWrapper } from "./styled"
 import {
   PaymentSourceName,
   PaymentSourceCreditCardEndingIn,
-  PaymentSourceCreditCardValidUntil,
+  PaymentSourceCreditCardExpires,
 } from "#components/ui/PaymentSource"
 import {
   PaymentSourceBrandIconWrapper,
@@ -34,7 +34,7 @@ export function PaymentSourceRow(): JSX.Element {
                   <PaymentSourceName />
                   <PaymentSourceCreditCardEndingIn />
                 </PaymentSourceTextWrapper>
-                <PaymentSourceCreditCardValidUntil />
+                <PaymentSourceCreditCardExpires variant="row" />
               </>
             )
           }}

--- a/packages/my-account/src/components/ui/PaymentSource/Row/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Row/index.tsx
@@ -1,0 +1,45 @@
+import { PaymentSourceBrandIcon } from "@commercelayer/react-components/payment_source/PaymentSourceBrandIcon"
+import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
+
+import { PaymentSourceWrapper, PaymentSourceBrandNameWrapper } from "./styled"
+
+import {
+  PaymentSourceName,
+  PaymentSourceCreditCardEndingIn,
+  PaymentSourceCreditCardValidUntil,
+} from "#components/ui/PaymentSource"
+import {
+  PaymentSourceBrandIconWrapper,
+  PaymentSourceTextWrapper,
+} from "#components/ui/PaymentSource/styled"
+
+export function PaymentSourceRow(): JSX.Element {
+  return (
+    <PaymentSourceWrapper>
+      <PaymentSourceBrandIconWrapper>
+        <PaymentSourceBrandIcon />
+      </PaymentSourceBrandIconWrapper>
+      <PaymentSourceBrandNameWrapper>
+        <PaymentSourceDetail type="last4">
+          {(props) => {
+            if (props.text === null || props.text.length === 0)
+              return (
+                <PaymentSourceTextWrapper>
+                  <PaymentSourceName />
+                </PaymentSourceTextWrapper>
+              )
+            return (
+              <>
+                <PaymentSourceTextWrapper>
+                  <PaymentSourceName />
+                  <PaymentSourceCreditCardEndingIn />
+                </PaymentSourceTextWrapper>
+                <PaymentSourceCreditCardValidUntil />
+              </>
+            )
+          }}
+        </PaymentSourceDetail>
+      </PaymentSourceBrandNameWrapper>
+    </PaymentSourceWrapper>
+  )
+}

--- a/packages/my-account/src/components/ui/PaymentSource/Row/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/Row/styled.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components"
+import tw from "twin.macro"
+
+export const PaymentSourceWrapper = styled.div`
+  ${tw`rounded flex bg-gray-50 items-center px-4 h-[52px]`}
+`
+
+export const PaymentSourceBrandNameWrapper = styled.div`
+  ${tw`flex flex-col w-full text-sm ml-6`}
+`

--- a/packages/my-account/src/components/ui/PaymentSource/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/index.tsx
@@ -42,10 +42,10 @@ export function PaymentSourceCreditCardEndingIn(): JSX.Element {
 function PaymentSourceCreditCardAsterisks(): JSX.Element {
   return (
     <div className="flex items-center">
-      <AsteriskSimple weight="bold" size={10} />
-      <AsteriskSimple weight="bold" size={10} />
-      <AsteriskSimple weight="bold" size={10} />
-      <AsteriskSimple weight="bold" size={10} />
+      <AsteriskSimple size={8} />
+      <AsteriskSimple size={8} />
+      <AsteriskSimple size={8} />
+      <AsteriskSimple size={8} />
     </div>
   )
 }
@@ -63,8 +63,8 @@ function PaymentSourceCreditCardAsterisksGroup(): JSX.Element {
 function PaymentSourceCreditCardExpiresAsterisks(): JSX.Element {
   return (
     <div className="flex items-center">
-      <AsteriskSimple weight="bold" size={8} />
-      <AsteriskSimple weight="bold" size={8} />
+      <AsteriskSimple size={8} />
+      <AsteriskSimple size={8} />
     </div>
   )
 }

--- a/packages/my-account/src/components/ui/PaymentSource/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/index.tsx
@@ -48,25 +48,23 @@ export function PaymentSourceCreditCardNumber(): JSX.Element {
     </PaymentSourceNumberWrapper>
   )
 }
-
-export function PaymentSourceCreditCardValidUntil(): JSX.Element {
-  return (
-    <PaymentSourceTextSecondary>
-      <Trans i18nKey="paymentSource.validUntil">
-        <PaymentSourceDetail type="exp_month" />
-        <PaymentSourceDetail type="exp_year" />
-      </Trans>
-    </PaymentSourceTextSecondary>
-  )
+interface PaymentSourceCreditCardExpiresProps {
+  variant: "row" | "card"
 }
 
-export function PaymentSourceCreditCardExpires(): JSX.Element {
-  return (
-    <PaymentSourceNumberSecondary>
-      <Trans i18nKey="paymentSource.expires">
-        <PaymentSourceDetail type="exp_month" />
-        <PaymentSourceDetail type="exp_year" />
-      </Trans>
-    </PaymentSourceNumberSecondary>
+export function PaymentSourceCreditCardExpires({
+  variant,
+}: PaymentSourceCreditCardExpiresProps): JSX.Element {
+  const label = (
+    <Trans i18nKey="paymentSource.expires">
+      <PaymentSourceDetail type="exp_month" />
+      <PaymentSourceDetail type="exp_year" />
+    </Trans>
+  )
+
+  return variant === "card" ? (
+    <PaymentSourceNumberSecondary>{label}</PaymentSourceNumberSecondary>
+  ) : (
+    <PaymentSourceTextSecondary>{label}</PaymentSourceTextSecondary>
   )
 }

--- a/packages/my-account/src/components/ui/PaymentSource/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/index.tsx
@@ -1,0 +1,72 @@
+import { PaymentSourceBrandName } from "@commercelayer/react-components/payment_source/PaymentSourceBrandName"
+import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
+import { Trans, useTranslation } from "react-i18next"
+
+import {
+  PaymentSourceTextPrimary,
+  PaymentSourceTextSecondary,
+  PaymentSourceNumberWrapper,
+  PaymentSourceNumberPrimary,
+  PaymentSourceNumberSecondary,
+} from "./styled"
+
+import { getTranslations } from "#utils/payments"
+
+export function PaymentSourceName(): JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <PaymentSourceBrandName>
+      {(props) => {
+        return props?.brand ? (
+          <PaymentSourceTextPrimary>
+            {getTranslations(props?.brand, t)}
+          </PaymentSourceTextPrimary>
+        ) : null
+      }}
+    </PaymentSourceBrandName>
+  )
+}
+
+export function PaymentSourceCreditCardEndingIn(): JSX.Element {
+  return (
+    <PaymentSourceTextPrimary>
+      <Trans i18nKey="paymentSource.endingIn">
+        <PaymentSourceDetail type="last4" />
+      </Trans>
+    </PaymentSourceTextPrimary>
+  )
+}
+
+export function PaymentSourceCreditCardNumber(): JSX.Element {
+  return (
+    <PaymentSourceNumberWrapper>
+      <Trans i18nKey="paymentSource.number" />
+      <PaymentSourceNumberPrimary>
+        <PaymentSourceDetail type="last4" />
+      </PaymentSourceNumberPrimary>
+    </PaymentSourceNumberWrapper>
+  )
+}
+
+export function PaymentSourceCreditCardValidUntil(): JSX.Element {
+  return (
+    <PaymentSourceTextSecondary>
+      <Trans i18nKey="paymentSource.validUntil">
+        <PaymentSourceDetail type="exp_month" />
+        <PaymentSourceDetail type="exp_year" />
+      </Trans>
+    </PaymentSourceTextSecondary>
+  )
+}
+
+export function PaymentSourceCreditCardExpires(): JSX.Element {
+  return (
+    <PaymentSourceNumberSecondary>
+      <Trans i18nKey="paymentSource.expires">
+        <PaymentSourceDetail type="exp_month" />
+        <PaymentSourceDetail type="exp_year" />
+      </Trans>
+    </PaymentSourceNumberSecondary>
+  )
+}

--- a/packages/my-account/src/components/ui/PaymentSource/index.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/index.tsx
@@ -1,5 +1,6 @@
 import { PaymentSourceBrandName } from "@commercelayer/react-components/payment_source/PaymentSourceBrandName"
 import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
+import { AsteriskSimple } from "phosphor-react"
 import { Trans, useTranslation } from "react-i18next"
 
 import {
@@ -38,12 +39,50 @@ export function PaymentSourceCreditCardEndingIn(): JSX.Element {
   )
 }
 
+function PaymentSourceCreditCardAsterisks(): JSX.Element {
+  return (
+    <div className="flex items-center">
+      <AsteriskSimple weight="bold" size={10} />
+      <AsteriskSimple weight="bold" size={10} />
+      <AsteriskSimple weight="bold" size={10} />
+      <AsteriskSimple weight="bold" size={10} />
+    </div>
+  )
+}
+
+function PaymentSourceCreditCardAsterisksGroup(): JSX.Element {
+  return (
+    <div className="flex items-center py-1 gap-1">
+      <PaymentSourceCreditCardAsterisks />
+      <PaymentSourceCreditCardAsterisks />
+      <PaymentSourceCreditCardAsterisks />
+    </div>
+  )
+}
+
+function PaymentSourceCreditCardExpiresAsterisks(): JSX.Element {
+  return (
+    <div className="flex items-center">
+      <AsteriskSimple weight="bold" size={8} />
+      <AsteriskSimple weight="bold" size={8} />
+    </div>
+  )
+}
+
 export function PaymentSourceCreditCardNumber(): JSX.Element {
   return (
     <PaymentSourceNumberWrapper>
-      <Trans i18nKey="paymentSource.number" />
+      <PaymentSourceCreditCardAsterisksGroup />
       <PaymentSourceNumberPrimary>
-        <PaymentSourceDetail type="last4" />
+        <PaymentSourceDetail type="last4">
+          {({ text }) => {
+            return text === "****" ? (
+              <PaymentSourceCreditCardAsterisks />
+            ) : (
+              <span>{text}</span>
+            )
+          }}
+        </PaymentSourceDetail>
       </PaymentSourceNumberPrimary>
     </PaymentSourceNumberWrapper>
   )
@@ -55,11 +94,37 @@ interface PaymentSourceCreditCardExpiresProps {
 export function PaymentSourceCreditCardExpires({
   variant,
 }: PaymentSourceCreditCardExpiresProps): JSX.Element {
+  const expiry_month = (
+    <PaymentSourceDetail type="exp_month">
+      {({ text }) =>
+        text === "**" ? (
+          <PaymentSourceCreditCardExpiresAsterisks />
+        ) : (
+          <span>{text}</span>
+        )
+      }
+    </PaymentSourceDetail>
+  )
+
+  const exp_year = (
+    <PaymentSourceDetail type="exp_year">
+      {({ text }) =>
+        text === "**" ? (
+          <PaymentSourceCreditCardExpiresAsterisks />
+        ) : (
+          <span>{text.toString().slice(-2)}</span>
+        )
+      }
+    </PaymentSourceDetail>
+  )
+
   const label = (
-    <Trans i18nKey="paymentSource.expires">
-      <PaymentSourceDetail type="exp_month" />
-      <PaymentSourceDetail type="exp_year" />
-    </Trans>
+    <div className="flex items-center gap-1">
+      <Trans i18nKey="paymentSource.expires" />
+      <div className="flex">
+        {expiry_month}/{exp_year}
+      </div>
+    </div>
   )
 
   return variant === "card" ? (

--- a/packages/my-account/src/components/ui/PaymentSource/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/styled.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components"
+import tw from "twin.macro"
+
+export const PaymentSourceBrandIconWrapper = styled.div`
+  ${tw` `}
+`
+
+export const PaymentSourceBrandNameWrapper = styled.div`
+  ${tw`flex flex-col w-full text-sm `}
+`
+
+export const PaymentSourceTextWrapper = styled.div`
+  ${tw`flex gap-1`}
+`
+
+export const PaymentSourceTextPrimary = styled.div`
+  ${tw`font-bold break-all`}
+`
+
+export const PaymentSourceTextSecondary = styled.div`
+  ${tw`font-light text-gray-500`}
+`
+
+export const PaymentSourceNumberWrapper = styled.div`
+  ${tw`flex gap-1 leading-[14px]`}
+`
+
+export const PaymentSourceNumberPrimary = styled.span`
+  ${tw`text-base leading-[16px] font-bold`}
+`
+
+export const PaymentSourceNumberSecondary = styled.span`
+  ${tw`text-xs text-gray-400 leading-[13px]`}
+`

--- a/packages/my-account/src/components/ui/PaymentSource/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/styled.tsx
@@ -22,13 +22,13 @@ export const PaymentSourceTextSecondary = styled.div`
 `
 
 export const PaymentSourceNumberWrapper = styled.div`
-  ${tw`flex items-center gap-1 leading-[14px]`}
+  ${tw`flex items-center gap-1 min-h-[20px] leading-[20px]`}
 `
 
 export const PaymentSourceNumberPrimary = styled.span`
-  ${tw`text-base leading-[16px] font-bold`}
+  ${tw`text-[15px] leading-[20px] font-bold text-black`}
 `
 
 export const PaymentSourceNumberSecondary = styled.span`
-  ${tw`antialiased text-sm leading-[14px] text-gray-500`}
+  ${tw`antialiased text-[13px] leading-[20px] text-gray-400 mt-[4px]`}
 `

--- a/packages/my-account/src/components/ui/PaymentSource/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/styled.tsx
@@ -22,7 +22,7 @@ export const PaymentSourceTextSecondary = styled.div`
 `
 
 export const PaymentSourceNumberWrapper = styled.div`
-  ${tw`flex gap-1 leading-[14px]`}
+  ${tw`flex items-center gap-1 leading-[14px]`}
 `
 
 export const PaymentSourceNumberPrimary = styled.span`
@@ -30,5 +30,5 @@ export const PaymentSourceNumberPrimary = styled.span`
 `
 
 export const PaymentSourceNumberSecondary = styled.span`
-  ${tw`font-light text-[13px] text-gray-500 leading-[13px]`}
+  ${tw`antialiased text-sm leading-[14px] text-gray-500`}
 `

--- a/packages/my-account/src/components/ui/PaymentSource/styled.tsx
+++ b/packages/my-account/src/components/ui/PaymentSource/styled.tsx
@@ -30,5 +30,5 @@ export const PaymentSourceNumberPrimary = styled.span`
 `
 
 export const PaymentSourceNumberSecondary = styled.span`
-  ${tw`text-xs text-gray-400 leading-[13px]`}
+  ${tw`font-light text-[13px] text-gray-500 leading-[13px]`}
 `

--- a/packages/my-account/src/data/routes.ts
+++ b/packages/my-account/src/data/routes.ts
@@ -17,4 +17,8 @@ export const appRoutes = {
     path: "/addresses/:addressId/edit",
     makePath: (addressId: string) => `/addresses/${addressId}/edit`,
   },
+  wallet: {
+    path: "/wallet",
+    makePath: () => "/wallet",
+  },
 }

--- a/packages/my-account/src/pages/WalletPage/index.tsx
+++ b/packages/my-account/src/pages/WalletPage/index.tsx
@@ -1,11 +1,9 @@
-import { CustomerPaymentSource } from "@commercelayer/react-components/customers/CustomerPaymentSource"
 import CustomerPaymentSourceEmpty from "@commercelayer/react-components/customers/CustomerPaymentSourceEmpty"
-import { PaymentSourceBrandIcon } from "@commercelayer/react-components/payment_source/PaymentSourceBrandIcon"
-import { PaymentSourceBrandName } from "@commercelayer/react-components/payment_source/PaymentSourceBrandName"
-import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
 import { useTranslation } from "react-i18next"
 
 import Empty from "#components/composite/Empty"
+import CustomerPaymentCard from "#components/ui/CustomerPaymentCard"
+import { GridContainer } from "#components/ui/GridContainer"
 import Title from "#components/ui/Title"
 
 function WalletPage(): JSX.Element {
@@ -17,19 +15,9 @@ function WalletPage(): JSX.Element {
       <CustomerPaymentSourceEmpty>
         {() => <Empty type="PaymentMethods" />}
       </CustomerPaymentSourceEmpty>
-      <CustomerPaymentSource>
-        <PaymentSourceBrandIcon />
-        <PaymentSourceBrandName />
-        <PaymentSourceDetail type="last4" />
-        <PaymentSourceDetail
-          type="exp_month"
-          data-testid="payment-source-exp-month"
-        />
-        <PaymentSourceDetail
-          type="exp_year"
-          data-testid="payment-source-exp-year"
-        />
-      </CustomerPaymentSource>
+      <GridContainer>
+        <CustomerPaymentCard />
+      </GridContainer>
     </>
   )
 }

--- a/packages/my-account/src/pages/WalletPage/index.tsx
+++ b/packages/my-account/src/pages/WalletPage/index.tsx
@@ -1,7 +1,37 @@
+import { CustomerPaymentSource } from "@commercelayer/react-components/customers/CustomerPaymentSource"
+import CustomerPaymentSourceEmpty from "@commercelayer/react-components/customers/CustomerPaymentSourceEmpty"
+import { PaymentSourceBrandIcon } from "@commercelayer/react-components/payment_source/PaymentSourceBrandIcon"
+import { PaymentSourceBrandName } from "@commercelayer/react-components/payment_source/PaymentSourceBrandName"
+import { PaymentSourceDetail } from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
+import { useTranslation } from "react-i18next"
+
 import Empty from "#components/composite/Empty"
+import Title from "#components/ui/Title"
 
 function WalletPage(): JSX.Element {
-  return <Empty type="PaymentMethods" />
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <Title>{t("wallet.title")}</Title>
+      <CustomerPaymentSourceEmpty>
+        {() => <Empty type="PaymentMethods" />}
+      </CustomerPaymentSourceEmpty>
+      <CustomerPaymentSource>
+        <PaymentSourceBrandIcon />
+        <PaymentSourceBrandName />
+        <PaymentSourceDetail type="last4" />
+        <PaymentSourceDetail
+          type="exp_month"
+          data-testid="payment-source-exp-month"
+        />
+        <PaymentSourceDetail
+          type="exp_year"
+          data-testid="payment-source-exp-year"
+        />
+      </CustomerPaymentSource>
+    </>
+  )
 }
 
 export default WalletPage

--- a/packages/my-account/src/providers/CustomerContainerProvider/index.tsx
+++ b/packages/my-account/src/providers/CustomerContainerProvider/index.tsx
@@ -2,7 +2,7 @@ import { CustomerContainer } from "@commercelayer/react-components/customers/Cus
 import type { Settings } from "HostedApp"
 
 type CustomerContainerProviderProps = Pick<Settings, "isGuest"> & {
-  children: React.ReactNode
+  children: JSX.Element | JSX.Element[] | null
 }
 
 export function CustomerContainerProvider({

--- a/packages/my-account/src/utils/payments.ts
+++ b/packages/my-account/src/utils/payments.ts
@@ -13,14 +13,14 @@ export function getTranslations(value: string, t: (a: string) => string) {
     case "Adyen Payment":
     case "Braintree Payment":
     case "Checkout Com Payment":
-      return t("order.payments.paymentMethod.creditCard")
+      return t("paymentSource.creditCard")
 
     case "Paypal Payment":
       return "PayPal"
 
     case "Wire transfer":
     case "Wire Transfer":
-      return t("order.payments.paymentMethod.wireTransfer")
+      return t("paymentSource.wireTransfer")
 
     default:
       return value || ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
   packages/my-account:
     specifiers:
       '@commercelayer/js-auth': ^2.3.0
-      '@commercelayer/react-components': 4.1.0
+      '@commercelayer/react-components': 4.2.3-beta.0
       '@commercelayer/react-utils': 1.0.0-beta.3
       '@commercelayer/sdk': ^4.20.0
       '@esbuild-plugins/node-globals-polyfill': ^0.1.1
@@ -74,7 +74,7 @@ importers:
       wouter: ^2.8.1
       zod: 3.20.2
     dependencies:
-      '@commercelayer/react-components': 4.1.0_biqbaboplfbrettd7655fr4n2y
+      '@commercelayer/react-components': 4.2.3-beta.0_biqbaboplfbrettd7655fr4n2y
       '@commercelayer/react-utils': 1.0.0-beta.3_bvai3i5a2wg6lfiumjdxdzymmm
       '@commercelayer/sdk': 4.20.0
       '@esbuild-plugins/node-globals-polyfill': 0.1.1
@@ -151,8 +151,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@adyen/adyen-web/5.31.3:
-    resolution: {integrity: sha512-37LM16goSP0vTN2QWopT6qJeIdQsg+cy5MB2+5Gd3ZoKjS3033qwX6kNcgocstBMS/sxYw4+hRy2zDl5vth1xA==}
+  /@adyen/adyen-web/5.33.0:
+    resolution: {integrity: sha512-UKYjlEVasf4D4ujVxsAb9dvY+oDhNxM7KaBZMFJ7l3sU9bHE037g3Y1+3yraUxJaHfSJQnNVHGrTd3QmQZntbA==}
     dependencies:
       '@babel/runtime': 7.20.6
       '@babel/runtime-corejs3': 7.20.6
@@ -512,23 +512,22 @@ packages:
       tslib: 2.4.1
     dev: true
 
-  /@commercelayer/react-components/4.1.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-CDq/57QeSWFfSK13BRc/J8bXdLlpocso9hmRMwS+GN6Uj4M0J4ag5YVDPVENJ160V3I9wKNUKbqEkQim/Z/L9w==}
+  /@commercelayer/react-components/4.2.3-beta.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-T0UIhaFLqtwoL2ZsKBYeAPLFZZH0LNiUM1RO+dQYWum0LGB1o+tmoHCIbJIw1RCkp1LgSFh9Fw85NQpKNRE/Ug==}
     peerDependencies:
       react: ^18.0.0
     dependencies:
       '@ac-dev/countries-service': 1.2.0
       '@ac-dev/states-service': 1.1.1
-      '@adyen/adyen-web': 5.31.3
-      '@commercelayer/sdk': 4.21.0
+      '@adyen/adyen-web': 5.33.0
+      '@commercelayer/sdk': 4.25.0
       '@stripe/react-stripe-js': 1.16.4_keartrz7uyerl3wkpjpue4xbhy
       '@stripe/stripe-js': 1.46.0
-      axios: 1.2.3
+      axios: 1.3.4
       braintree-web: 3.90.0
       frames-react: 1.1.0_react@18.2.0
       jwt-decode: 3.1.2
       lodash: 4.17.21
-      lodash-es: 4.17.21
       rapid-form: 2.1.0
       react: 18.2.0
       react-table: 7.8.0_react@18.2.0
@@ -571,11 +570,11 @@ packages:
       - debug
     dev: false
 
-  /@commercelayer/sdk/4.21.0:
-    resolution: {integrity: sha512-eZI80LcME5qY2HgD/iuVGRED38LVpjrFWW3ghNKomH2z0zHusx0saLEL6V/g9EmJBMq0i9MAIh4zA7SkDpemIw==}
+  /@commercelayer/sdk/4.25.0:
+    resolution: {integrity: sha512-5PZflCUFy+daavuw5AEGJTDF3xbhwQQHMxImmgEh5N7li2lPyw+9pBZ1Aq/DSaYLsIgb/MhnIs8a/u6M7Gto/g==}
     engines: {node: '>=16 || ^14.17'}
     dependencies:
-      axios: 1.1.3
+      axios: 1.3.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2605,16 +2604,6 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /axios/1.1.3:
-    resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /axios/1.2.1:
     resolution: {integrity: sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==}
     dependencies:
@@ -2624,8 +2613,18 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /axios/1.2.3:
-    resolution: {integrity: sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==}
+  /axios/1.3.2:
+    resolution: {integrity: sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios/1.3.4:
+    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0
@@ -5830,10 +5829,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-
-  /lodash-es/4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
 
   /lodash.capitalize/4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
       '@commercelayer/js-auth': ^2.3.0
       '@commercelayer/react-components': 4.2.3-beta.0
       '@commercelayer/react-utils': 1.0.0-beta.3
-      '@commercelayer/sdk': ^4.20.0
+      '@commercelayer/sdk': ^4.24.0
       '@esbuild-plugins/node-globals-polyfill': ^0.1.1
       '@faker-js/faker': ^7.3.0
       '@headlessui/react': ^1.6.4
@@ -76,7 +76,7 @@ importers:
     dependencies:
       '@commercelayer/react-components': 4.2.3-beta.0_biqbaboplfbrettd7655fr4n2y
       '@commercelayer/react-utils': 1.0.0-beta.3_bvai3i5a2wg6lfiumjdxdzymmm
-      '@commercelayer/sdk': 4.20.0
+      '@commercelayer/sdk': 4.25.0
       '@esbuild-plugins/node-globals-polyfill': 0.1.1
       '@headlessui/react': 1.7.5_biqbaboplfbrettd7655fr4n2y
       '@tailwindcss/forms': 0.5.3_tailwindcss@3.2.4
@@ -559,15 +559,6 @@ packages:
       - react-is
       - supports-color
       - tailwindcss
-    dev: false
-
-  /@commercelayer/sdk/4.20.0:
-    resolution: {integrity: sha512-jPTv6YML4DM6UvucXwsSazWOjhuYzHbHeQLe3nSgHrQy4zL6cE4YTo0N87+mARa45w+rKZL6DwKyn1lN66Qf7g==}
-    engines: {node: '>=16 || ^14.17'}
-    dependencies:
-      axios: 1.2.1
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /@commercelayer/sdk/4.25.0:
@@ -2604,15 +2595,6 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /axios/1.2.1:
-    resolution: {integrity: sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   /axios/1.3.2:
     resolution: {integrity: sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==}
     dependencies:
@@ -2631,7 +2613,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /babel-plugin-macros/2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
@@ -6585,7 +6566,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.32
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.2.1
+      axios: 1.3.4
       chalk: 4.1.0
       chokidar: 3.5.3
       cli-cursor: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
   packages/my-account:
     specifiers:
       '@commercelayer/js-auth': ^2.3.0
-      '@commercelayer/react-components': 4.2.3-beta.0
+      '@commercelayer/react-components': 4.2.3-beta.1
       '@commercelayer/react-utils': 1.0.0-beta.3
       '@commercelayer/sdk': ^4.24.0
       '@esbuild-plugins/node-globals-polyfill': ^0.1.1
@@ -74,7 +74,7 @@ importers:
       wouter: ^2.8.1
       zod: 3.20.2
     dependencies:
-      '@commercelayer/react-components': 4.2.3-beta.0_biqbaboplfbrettd7655fr4n2y
+      '@commercelayer/react-components': 4.2.3-beta.1_biqbaboplfbrettd7655fr4n2y
       '@commercelayer/react-utils': 1.0.0-beta.3_bvai3i5a2wg6lfiumjdxdzymmm
       '@commercelayer/sdk': 4.25.0
       '@esbuild-plugins/node-globals-polyfill': 0.1.1
@@ -151,8 +151,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /@adyen/adyen-web/5.33.0:
-    resolution: {integrity: sha512-UKYjlEVasf4D4ujVxsAb9dvY+oDhNxM7KaBZMFJ7l3sU9bHE037g3Y1+3yraUxJaHfSJQnNVHGrTd3QmQZntbA==}
+  /@adyen/adyen-web/5.35.0:
+    resolution: {integrity: sha512-2WjRTXoNq/laUIymufeyo5CgOHM2+nIdpxzSeIcAU6AH9qvLLpcfRcLkR+VDiFC32wj7PGSrrEDe6sLYSyq0sg==}
     dependencies:
       '@babel/runtime': 7.20.6
       '@babel/runtime-corejs3': 7.20.6
@@ -512,19 +512,19 @@ packages:
       tslib: 2.4.1
     dev: true
 
-  /@commercelayer/react-components/4.2.3-beta.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-T0UIhaFLqtwoL2ZsKBYeAPLFZZH0LNiUM1RO+dQYWum0LGB1o+tmoHCIbJIw1RCkp1LgSFh9Fw85NQpKNRE/Ug==}
+  /@commercelayer/react-components/4.2.3-beta.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-z+x1Yah+sGQjJVi/AptnEg+eEwXRoehKJ7enEeiBAl74jMKSGT47VWw4N9MnS3n59tsuO+mWMzgqMWIcsG8f6A==}
     peerDependencies:
       react: ^18.0.0
     dependencies:
       '@ac-dev/countries-service': 1.2.0
       '@ac-dev/states-service': 1.1.1
-      '@adyen/adyen-web': 5.33.0
+      '@adyen/adyen-web': 5.35.0
       '@commercelayer/sdk': 4.25.0
-      '@stripe/react-stripe-js': 1.16.4_keartrz7uyerl3wkpjpue4xbhy
-      '@stripe/stripe-js': 1.46.0
+      '@stripe/react-stripe-js': 1.16.5_weqjxr3p5t2q35nshpdpqrergy
+      '@stripe/stripe-js': 1.48.0
       axios: 1.3.4
-      braintree-web: 3.90.0
+      braintree-web: 3.91.0
       frames-react: 1.1.0_react@18.2.0
       jwt-decode: 3.1.2
       lodash: 4.17.21
@@ -1921,21 +1921,21 @@ packages:
     resolution: {integrity: sha512-sBSO19KzdrJCM3gdx6eIxV8M9Gxfgg6iDQmH5TIAGaUu+X9VDdsINXJOnoiZ1Kx3TrHdH4bt5UVglkjsEGBcvw==}
     dev: true
 
-  /@stripe/react-stripe-js/1.16.4_keartrz7uyerl3wkpjpue4xbhy:
-    resolution: {integrity: sha512-x+Zstd3mHctNbSATOdbA2rOVXqGhbLU1ziNgcWqYCaFXj2dPKzjkBiUJfDhoARJVXVGOts0oZ8teTkOFY/ZRzQ==}
+  /@stripe/react-stripe-js/1.16.5_weqjxr3p5t2q35nshpdpqrergy:
+    resolution: {integrity: sha512-lVPW3IfwdacyS22pP+nBB6/GNFRRhT/4jfgAK6T2guQmtzPwJV1DogiGGaBNhiKtSY18+yS8KlHSu+PvZNclvQ==}
     peerDependencies:
       '@stripe/stripe-js': ^1.44.1
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@stripe/stripe-js': 1.46.0
+      '@stripe/stripe-js': 1.48.0
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@stripe/stripe-js/1.46.0:
-    resolution: {integrity: sha512-dkm0zCEoRLu5rTnsIgwDf/QG2DKcalOT2dk1IVgMySOHWTChLyOvQwMYhEduGgLvyYWTwNhAUV4WOLPQvjwLwA==}
+  /@stripe/stripe-js/1.48.0:
+    resolution: {integrity: sha512-Kw2BRXk6z/wnTU9m2IJOhxJNrx9xzmpFSbk6D/Z0x6LJntMafiHeHFag2PvSF30O2quMb1UUdWsnZqGVDruZww==}
     dev: false
 
   /@tailwindcss/forms/0.5.3_tailwindcss@3.2.4:
@@ -2712,8 +2712,8 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
-  /braintree-web/3.90.0:
-    resolution: {integrity: sha512-jMz0EirJLme+OP0TjYk3/esbkPfpei3tc/pC/7a6WIXFyNcjp0y5k+yw9jQKQW0pGpt3goypPqkO4jRAv2b86g==}
+  /braintree-web/3.91.0:
+    resolution: {integrity: sha512-7fiYRDY+f7bZ322Uk0iBFuanLyrDd1GKKwPUElbhbRS3AtImoSeGFvwvGfyxDo+vrLAoa7OghhcfI+rPY7xY6Q==}
     dependencies:
       '@braintree/asset-loader': 0.4.4
       '@braintree/browser-detection': 1.14.0


### PR DESCRIPTION
### What does this PR do?
Add new Wallet page in readonly mode to provide a list of customer saved payment sources. (Closes #89)

<img width="727" alt="Screenshot 2023-02-27 alle 17 37 10" src="https://user-images.githubusercontent.com/105653649/221623999-28f66792-8059-46da-9865-7e25124b0aee.png">