### PR TITLE
Fix `AddressCard`s hover effect, text size and actions margin

### DIFF
--- a/packages/my-account/src/components/ui/AddressCard/index.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/index.tsx
@@ -74,8 +74,7 @@ export function AddressCard({
               label={t("addresses.yes") as string}
               className="address-confirm-delete-button"
               onClick={() => {
-                // TODO: Do we need to introduce a visual confirmation of address deletion?
-                return false
+                setShowDeleteConfirmation(false)
               }}
             />
             {/* <ConfirmCancel onClick={() => setShowDeleteConfirmation(false)}>

--- a/packages/my-account/src/components/ui/AddressCard/index.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/index.tsx
@@ -7,7 +7,6 @@ import { useLocation } from "wouter"
 import {
   EditButton,
   Wrapper,
-  Content,
   Customer,
   Address,
   ActionsWrapper,
@@ -21,6 +20,7 @@ import {
   DeleteButton,
 } from "./styled"
 
+import { GridCard } from "#components/ui/GridCard"
 import { appRoutes } from "#data/routes"
 import { AppContext } from "#providers/AppProvider"
 
@@ -77,13 +77,10 @@ export function AddressCard({
                 setShowDeleteConfirmation(false)
               }}
             />
-            {/* <ConfirmCancel onClick={() => setShowDeleteConfirmation(false)}>
-              {t("addresses.no")}
-            </ConfirmCancel> */}
           </ConfirmActions>
         </Overlay>
       )}
-      <Content>
+      <GridCard>
         <Customer data-cy={`fullname_${addressType}`}>
           {first_name} {last_name}
         </Customer>
@@ -123,7 +120,7 @@ export function AddressCard({
             </Actions>
           </ActionsWrapper>
         )}
-      </Content>
+      </GridCard>
     </Wrapper>
   )
 }

--- a/packages/my-account/src/components/ui/AddressCard/styled.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/styled.tsx
@@ -14,11 +14,11 @@ export const Customer = styled.p`
 `
 
 export const Address = styled.p`
-  ${tw`text-[13px] text-gray-400`}
+  ${tw`text-[13px] text-gray-400 antialiased`}
 `
 
 export const ActionsWrapper = styled.div`
-  ${tw`flex flex-col justify-end pt-4`}
+  ${tw`flex flex-col justify-end pt-2`}
 `
 
 export const Actions = styled.div`

--- a/packages/my-account/src/components/ui/AddressCard/styled.tsx
+++ b/packages/my-account/src/components/ui/AddressCard/styled.tsx
@@ -8,16 +8,13 @@ import { LinkButton } from "#components/ui/LinkButton"
 export const Wrapper = styled.div`
   ${tw`relative transition duration-200 ease-in bg-white md:bg-transparent focus:shadow-sm`}
 `
-export const Content = styled.div`
-  ${tw`px-5 py-4 rounded border border-gray-200 group-hover:(border-primary shadow-sm-primary)`}
-`
 
 export const Customer = styled.p`
   ${tw`font-bold text-md`}
 `
 
 export const Address = styled.p`
-  ${tw`text-sm text-gray-400`}
+  ${tw`text-[13px] text-gray-400`}
 `
 
 export const ActionsWrapper = styled.div`


### PR DESCRIPTION
### What does this PR do?
Fix `AddressCard`s hover effect, text size and actions margin. Closes #118 

Actual behaviour:
<img width="483" alt="Screenshot 2023-03-09 alle 16 34 30" src="https://user-images.githubusercontent.com/105653649/224073859-fe6172ab-489a-4f6f-bb20-6a427917894e.png">

Wanted behaviour:
<img width="458" alt="Screenshot 2023-03-09 alle 16 34 53" src="https://user-images.githubusercontent.com/105653649/224073976-a7ac584a-e8c7-4b60-85b1-1caa5044b854.png">
